### PR TITLE
Add support for using bad characters as separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ your tailwind.config.js.
   - [variantChar: `[string]`](#variantchar-string)
   - [separatorChar: `[string]`](#separatorchar-string)
   - [expandOpenChar: `[string]` and expandCloseChar: `[string]`](#expandopenchar-string-and-expandclosechar-string)
+  - [compressWhitespaces: `[boolean]`](#compresswhitespaces-boolean)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
   - [💡 Feature Requests](#-feature-requests)
@@ -238,6 +239,51 @@ will be transformed to:
 export default function Hero({children}) {
   return (
     <div className="relative z-10 pb-8 bg-white sm:pb-16 md:pb-20 lg:max-w-2xl lg:w-full lg:pb-2 xl:pb-32">
+      {children}
+    </div>
+  )
+}
+```
+
+### compressWhitespaces: `[boolean]`
+
+- compressWhitespaces: _Default: `false`_
+
+This allows users to allow compressing the whitespaces in their files. This is
+added as a paramter so it doesn't break any existing user setups.
+
+Change the call to `createTransformer` in your `tailwind.config.js`.
+
+```javascript
+// tailwind.config.js
+const createTransformer = require('tailwind-group-variant')
+module.exports = {
+  content: {
+    files: ['./app/**/*.{ts,tsx,jsx,js,mdx}'],
+    transform: createTransformer({ compressWhitespaces: true }),
+  },
+  ...
+}
+```
+
+The whitespaces in your components:
+
+```tsx
+export default function Hero({children}) {
+  return (
+    <div className="  relative       z-10 pb-8   sm:pb-16 md:pb-20   lg:(    max-w-2xl,w-full   ) xl:pb-32  ">
+      {children}
+    </div>
+  )
+}
+```
+
+will be transformed to:
+
+```tsx
+export default function Hero({children}) {
+  return (
+    <div className="relative z-10 pb-8 sm:pb-16 md:pb-20 lg:max-w-2xl lg:w-full xl:pb-32">
       {children}
     </div>
   )

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -76,6 +76,44 @@ describe.each(Object.entries(tests))(
   },
 )
 
+const testsWithoutWhitespace: Record<string, TestCase> = {
+  'bad char after variant': {
+    input: `test dark: (p-2,m-3 lg:(p-3,m-4) )`,
+    output: `test dark: (p-2,m-3 lg:p-3 lg:m-4)`,
+  },
+  'bad char after stack opens': {
+    input: `test dark:( p-2, lg:(p-3,m-4) )`,
+    output: `test dark:(p-2, lg:p-3 lg:m-4)`,
+  },
+  'extra spacing inside variants': {
+    input: `test dark:(   p-2,m-3 ) a`,
+    output: `test dark:p-2 dark:m-3 a`,
+  },
+  'extra spacing outside variants': {
+    input: `  test   dark:(p-2,m-3)  `,
+    output: `test dark:p-2 dark:m-3`,
+  },
+}
+
+describe.each(Object.entries(testsWithoutWhitespace))(
+  'group variants without whitespace',
+  (title, {input, output, only = false, skip = false, options}) => {
+    options = options ?? {}
+    options.compressWhitespaces = true
+
+    const testFn = () =>
+      expect(createTransformer(options)(input)).toEqual(output)
+
+    if (only) {
+      test.only(title, testFn)
+    } else if (skip) {
+      test.skip(title, testFn)
+    } else {
+      test(title, testFn)
+    }
+  },
+)
+
 /*
 eslint
   jest/valid-title: "off",

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -114,6 +114,77 @@ describe.each(Object.entries(testsWithoutWhitespace))(
   },
 )
 
+const badCharTests: Record<string, TestCase> = {
+  'normal variant': {
+    input: `test lg:p-2 lg:m-3`,
+    output: `test lg:p-2 lg:m-3`,
+  },
+  'expand variant': {
+    input: `test lg:(p-2 m-3)`,
+    output: `test lg:p-2 lg:m-3`,
+  },
+  'expand nested variant': {
+    input: `test dark:(p-2 m-3 lg:(p-3 m-4))`,
+    output: `test dark:p-2 dark:m-3 dark:lg:p-3 dark:lg:m-4`,
+  },
+  'only use nested variant when outer has error': {
+    input: `test dark:(p-2 m-3  lg:(p-3 m-4))`,
+    output: `test dark:p-2 dark:m-3 dark:lg:p-3 dark:lg:m-4`,
+  },
+  'bad char after variant': {
+    input: `test dark: (p-2 m-3 lg:(p-3 m-4) )`,
+    output: `test dark: (p-2 m-3 lg:p-3 lg:m-4)`,
+  },
+  'close after open': {
+    input: `test dark:() p-2 m-3 lg:(p-3 m-4)`,
+    output: `test dark:() p-2 m-3 lg:p-3 lg:m-4`,
+  },
+  'nested normal variant': {
+    input: `test dark:(p-2 m-3 hover:text-blue)`,
+    output: `test dark:p-2 dark:m-3 dark:hover:text-blue`,
+  },
+  'nested group in middle of group': {
+    input: `test dark:(p-2 m-3 hover:(text-blue bg-red) text-red)`,
+    output: `test dark:p-2 dark:m-3 dark:text-red dark:hover:text-blue dark:hover:bg-red`,
+  },
+  'random char after stack close': {
+    input: `test dark:(p-2 m-3)a`,
+    output: `test dark:p-2 dark:m-3a`,
+  },
+  'random char after nested stack close': {
+    input: `test dark:(p-2 m-3 lg:(p-3 m-4)a)`,
+    output: `test dark:(p-2 m-3 lg:p-3 lg:m-4a)`,
+  },
+  'extra spacing inside variants': {
+    input: `test dark:(   p-2 m-3 ) a`,
+    output: `test dark:p-2 dark:m-3 a`,
+  },
+  'extra spacing outside variants': {
+    input: `  test   dark:(p-2 m-3)  `,
+    output: `test dark:p-2 dark:m-3`,
+  },
+}
+
+describe.each(Object.entries(badCharTests))(
+  'group variants with bad char separator',
+  (title, {input, output, only = false, skip = false, options}) => {
+    options = options ?? {}
+    options.separatorChar = ' '
+    options.compressWhitespaces = true
+
+    const testFn = () =>
+      expect(createTransformer(options)(input)).toEqual(output)
+
+    if (only) {
+      test.only(title, testFn)
+    } else if (skip) {
+      test.skip(title, testFn)
+    } else {
+      test(title, testFn)
+    }
+  },
+)
+
 /*
 eslint
   jest/valid-title: "off",

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ type TransformOptions = {
   expandCloseChar?: string
   separatorChar?: string
   variantChar?: string
+  compressWhitespaces?: boolean
 }
 
 function stackClose(
@@ -221,7 +222,19 @@ const transformMachine: TransformMachine = {
   },
 }
 
+function compressWhitespaces(content: string) {
+  return content
+    .replace(/\s+/g, ' ')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim()
+}
+
 function transform(content: string, options?: TransformOptions) {
+  if (options?.compressWhitespaces) {
+    content = compressWhitespaces(content)
+  }
+
   const machineState: TransformMachineState = {
     context: {
       matches: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ const transformMachine: TransformMachine = {
     if (char === machineState.settings.variantChar) {
       machineState.context.variantEndIdx = idx
       machineState.state = State.variant
+    } else if (char === machineState.settings.separatorChar) {
+      machineState.context.variantStartIdx = idx + 1
     } else if (machineState.settings.badChars.includes(char)) {
       machineState.state = State.init
     }
@@ -235,6 +237,10 @@ function transform(content: string, options?: TransformOptions) {
     content = compressWhitespaces(content)
   }
 
+  let localBadChars = [...badChars, ...whitespaceChars].filter(
+    char => char !== options?.separatorChar,
+  )
+
   const machineState: TransformMachineState = {
     context: {
       matches: [],
@@ -245,7 +251,7 @@ function transform(content: string, options?: TransformOptions) {
     },
     state: State.init,
     settings: {
-      badChars: [...badChars, ...whitespaceChars],
+      badChars: localBadChars,
       expandClose: options?.expandCloseChar ?? ')',
       expandOpen: options?.expandOpenChar ?? '(',
       separatorChar: options?.separatorChar ?? ',',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added the ability to use bad characters as separators (like ` ` space).
Also added some logic to allow condensing whitespaces. This is useful for especially when a whitespace is set as a separator character

**Why**:
Currently, we cannot add bad characters as separators. Due to this, we cannot use common separators like ` ` (space)

**How**:
Added logic to check for separator and removed it from the badChars. Also added logic to allow user to condense whitespaces while testing the changes

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X ] Documentation
- [X] Tests
- [X] Ready to be merged

Closes #4 and #5
